### PR TITLE
Edit municipalities and region selection title

### DIFF
--- a/src/web/templates/index.tmpl
+++ b/src/web/templates/index.tmpl
@@ -85,7 +85,7 @@
     <form method="POST">
         <div class="form-fields">
             <div class="form-field">
-                <label for="munis">Municipalities</label>
+                <label for="munis">Municipalities & Regions</label>
                 <small><b>Note:</b> Not all geographies have data in each dataset.</small>
                 <select name="munis" multiple>
                     {% for muni in munis %}


### PR DESCRIPTION
I previously closed #7 because Massachusetts and the various state planning councils were already present in development, but I realized that I forgot to alter the title to reflect these non-singular-municipality regions. This commit is just to update that title from "Municipalities" to "Municipalities & Regions".